### PR TITLE
Fix bugs of token counter when audio modality is not used

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 duckdb==1.3.2
-# openai==1.95.1
+openai==1.95.1
 pandas==2.3.1
 sqlglot==27.0.0
 rich==13.9.4


### PR DESCRIPTION
`llm_reply.usage.prompt_tokens_details` is valid only when there exists audio modality when calling LLMs. When there is no audio, `text_tokens` and `image_tokens` would be None and crashes the execution. Using None check to make sure that the counter works for both (1) no audio is processed, and (2) audio is processed.