### PR TITLE
fix the bug of reusing a mutable kwargs dict across items

### DIFF
--- a/config/models.json
+++ b/config/models.json
@@ -1,17 +1,52 @@
 {
 	"models":[
 		{
+			"modalities":["text", "image"], "priority": 1,
+			"kwargs": {
+			    "filter": {
+					"model": "gemini-2.5-flash",
+					"temperature": 0,
+					"max_tokens": 1,
+					"reasoning_effort": "disable"
+				},
+				"join": {
+				    "model": "gemini-2.5-flash",
+					"temperature": 0,
+					"stop": ["."],
+					"reasoning_effort": "disable"
+                }
+			}
+		},
+		{
 			"modalities":["text", "image"], "priority": 10,
 			"kwargs": {
 			    "filter": {
-					"model": "gpt-5-mini"
+					"model": "gpt-5-mini",
+					"reasoning_effort": "minimal"
 				},
 				"join": {
-				    "model": "gpt-5-mini"
+				    "model": "gpt-5-mini",
+					"reasoning_effort": "minimal"
                 }
 			}
 		},
 		{"modalities":["text", "audio"], "priority": 10,
+	        "kwargs": {
+                "filter": {
+                    "model": "gemini-2.5-flash",
+					"temperature": 0,
+                    "max_tokens": 1,
+					"reasoning_effort": "disable"
+                },
+                "join": {
+                    "model": "gemini-2.5-flash",
+					"temperature": 0,
+                    "stop": ["."],
+					"reasoning_effort": "disable"
+                }
+            }
+        },
+		{"modalities":["text", "audio"], "priority": 1,
 	        "kwargs": {
                 "filter": {
                     "model": "gpt-4o-audio-preview",

--- a/src/tdb/operators/semantic_filter.py
+++ b/src/tdb/operators/semantic_filter.py
@@ -64,8 +64,8 @@ class UnaryFilter(SemanticOperator):
         inputs = []
         for item_text in item_texts:
             messages = [self._message(item_text)]
-            kwargs = self._best_model_args(messages)['filter']
-            kwargs['messages'] = messages
+            base = self._best_model_args(messages)['filter']
+            kwargs = {**base, 'messages': messages}          
             inputs.append((item_text, kwargs))
 
         # Use multiprocessing to evaluate predicates in parallel

--- a/src/tdb/operators/semantic_join.py
+++ b/src/tdb/operators/semantic_join.py
@@ -222,8 +222,8 @@ class NestedLoopJoin(SemanticJoin):
                 ]
             }
             messages = [message]
-            kwargs = self._best_model_args(messages)
-            kwargs['messages'] = messages
+            base = self._best_model_args(messages)
+            kwargs = {**base, 'messages': messages}
             response = completion(**kwargs)
             model = kwargs['model']
             self.update_cost_counters(model, response)
@@ -331,8 +331,8 @@ class BatchJoin(SemanticJoin):
         # Construct prompt for LLM
         prompt = self._create_prompt(left_items, right_items)
         messages = [prompt]
-        kwargs = self._best_model_args(messages)['join']
-        kwargs['messages'] = messages
+        base = self._best_model_args(messages)['join']
+        kwargs = {**base, 'messages': messages}
         response = completion(**kwargs)
         model = kwargs['model']
         self.update_cost_counters(model, response)

--- a/src/tdb/operators/semantic_join.py
+++ b/src/tdb/operators/semantic_join.py
@@ -290,8 +290,10 @@ class BatchJoin(SemanticJoin):
         content = llm_response.choices[0].message.content
         # print(content)
         matching_keys = []
+        content = content.replace(".", "")
         pairs_str = content.split(',')
         for pair_str in pairs_str:
+            pair_str = pair_str.strip()
             left_ref, right_ref = pair_str.split('-')
             left_idx = int(left_ref[1:])
             right_idx = int(right_ref[1:])


### PR DESCRIPTION
The bug comes from reusing a mutable kwargs dict across items, so every entry in the batch ends up pointing to the same dict with only the last messages value. As a result, the LLM is classifying the wrong text.